### PR TITLE
fix: use makefile for build:wasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,20 @@ to WebAssembly. It allows you to use Miniscript in NodeJS and in the browser.
 - [wasm-pack](https://rustwasm.github.io/wasm-pack/) (install with `cargo install wasm-pack`)
 - [NodeJS](https://nodejs.org/en/)
 
-# Building
 
-You can use the Docker image / Makefile to build the wasm files:
+# Packages
+
+## packages/wasm-miniscript
+
+This contains the core library that is compiled to WebAssembly.
+It is a wrapper around the `rust-miniscript` crate.
+
+###  Building
+
+If your system has problems with `wasm-pack` (Mac M1), you can use the `Container.mk` Makefile to build the wasm files:
 
 ```bash
-make build-image
-make build-wasm
+cd packages/wasm-miniscript
+make -f Container.mk build-image
+make -f Conatiner.mk build-wasm
 ```

--- a/packages/wasm-miniscript/Container.mk
+++ b/packages/wasm-miniscript/Container.mk
@@ -1,0 +1,26 @@
+.PHONY: all build-image build-wasm enter-image clean-container clean-image
+
+CONTAINER_ENGINE ?= docker
+
+all: build-image build-wasm
+
+build-image:
+	$(CONTAINER_ENGINE) build --tag wasm-builder .
+
+build-wasm:
+	rm -rf dist/ js/wasm/
+	$(CONTAINER_ENGINE) rm -f wasm-builder-container || true
+	$(CONTAINER_ENGINE) run -v $(shell pwd)/src:/usr/src/app/src \
+	--name wasm-builder-container wasm-builder \
+	npm run build
+	$(CONTAINER_ENGINE) cp wasm-builder-container:/usr/src/app/dist .
+	$(CONTAINER_ENGINE) cp wasm-builder-container:/usr/src/app/js/wasm ./js/wasm
+
+enter-image:
+	$(CONTAINER_ENGINE) run -it wasm-builder /bin/bash
+
+clean-container:
+	$(CONTAINER_ENGINE) rm wasm-builder-container
+
+clean-image:
+	$(CONTAINER_ENGINE) rmi wasm-builder

--- a/packages/wasm-miniscript/Makefile
+++ b/packages/wasm-miniscript/Makefile
@@ -1,26 +1,31 @@
-.PHONY: all build-image build-wasm enter-image clean-container clean-image
+WASM_PACK = wasm-pack
+WASM_PACK_FLAGS = --no-pack --weak-refs
 
-CONTAINER_ENGINE ?= docker
+ifdef WASM_PACK_DEV
+	WASM_PACK_FLAGS += --dev
+endif
 
-all: build-image build-wasm
+define WASM_PACK_COMMAND
+	$(WASM_PACK) build --out-dir $(1) $(WASM_PACK_FLAGS) --target $(2)
+endef
 
-build-image:
-	$(CONTAINER_ENGINE) build --tag wasm-builder .
+define REMOVE_GITIGNORE
+	find $(1) -name .gitignore -delete
+endef
 
-build-wasm:
-	rm -rf dist/ js/wasm/
-	$(CONTAINER_ENGINE) rm -f wasm-builder-container || true
-	$(CONTAINER_ENGINE) run -v $(shell pwd)/src:/usr/src/app/src \
-	--name wasm-builder-container wasm-builder \
-	npm run build
-	$(CONTAINER_ENGINE) cp wasm-builder-container:/usr/src/app/dist .
-	$(CONTAINER_ENGINE) cp wasm-builder-container:/usr/src/app/js/wasm ./js/wasm
+define BUILD
+	$(call WASM_PACK_COMMAND,$(1),$(2))
+	$(call REMOVE_GITIGNORE,$(1))
+endef
 
-enter-image:
-	$(CONTAINER_ENGINE) run -it wasm-builder /bin/bash
+.PHONY: js/wasm/
+js/wasm/:
+	$(call BUILD,$@,nodejs)
 
-clean-container:
-	$(CONTAINER_ENGINE) rm wasm-builder-container
+.PHONY: dist/wasm/
+dist/wasm/:
+	$(call BUILD,$@,nodejs)
 
-clean-image:
-	$(CONTAINER_ENGINE) rmi wasm-builder
+.PHONY: dist/browser/wasm/
+dist/browser/wasm/:
+	$(call BUILD,$@,browser)

--- a/packages/wasm-miniscript/package.json
+++ b/packages/wasm-miniscript/package.json
@@ -36,10 +36,7 @@
   },
   "scripts": {
     "test": "mocha --recursive test",
-    "build:wasm-dev": "wasm-pack build --out-dir js/wasm --no-pack --target nodejs --weak-refs",
-    "build:wasm-nodejs": "wasm-pack build --out-dir dist/wasm --no-pack --target nodejs --weak-refs",
-    "build:wasm-browser": "wasm-pack build --out-dir dist/browser/wasm --no-pack --target browser --weak-refs",
-    "build:wasm": "npm run build:wasm-dev && npm run build:wasm-nodejs && npm run build:wasm-browser",
+    "build:wasm": "make js/wasm/ && make dist/wasm/ && make dist/browser/wasm/",
     "build:ts-browser": "tsc --module es2020 --target es2020 --outDir dist/browser",
     "build:ts": "tsc && npm run build:ts-browser",
     "build": "npm run build:wasm && npm run build:ts",


### PR DESCRIPTION
This allows a more complex build process to be managed in a Makefile.

Turns out we have to remove the `.gitignore` files from the output directories
after `wasm-pack` builds the files, otherwise `npm pack` will not pick up the
wasm files.

Issue: BTC-1372
