### PR TITLE
bump miniscript dep

### DIFF
--- a/packages/wasm-miniscript/Cargo.lock
+++ b/packages/wasm-miniscript/Cargo.lock
@@ -122,9 +122,9 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "miniscript"
-version = "12.1.0"
+version = "12.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b01e2f1e8e4a5037b61f97de1619c7b2d3f6398aeaddbea9dd16ce9f5a9b33"
+checksum = "add2d4aee30e4291ce5cffa3a322e441ff4d4bc57b38c8d9bf0e94faa50ab626"
 dependencies = [
  "bech32",
  "bitcoin",

--- a/packages/wasm-miniscript/Cargo.toml
+++ b/packages/wasm-miniscript/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-miniscript = { version = "12.1.0", features = ["no-std"] }
+miniscript = { version = "12.1.0" }

--- a/packages/wasm-miniscript/Cargo.toml
+++ b/packages/wasm-miniscript/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-miniscript = { version = "12.1.0" }
+miniscript = { version = "12.2.0" }


### PR DESCRIPTION
- **fix: remove no-std feature from miniscript**
  We don't actually make use of the no-std feature
  
  Issue: BTC-1338
  

- **feat: bump miniscript to 12.2.0**
  Issue: BTC-1338
  