### PR TITLE
chore: remove no-std feature from wasm-miniscript

### DIFF
--- a/packages/wasm-miniscript/Cargo.toml
+++ b/packages/wasm-miniscript/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-miniscript = { version = "12.2.0", features = ["no-std"] }
+miniscript = { version = "12.2.0" }


### PR DESCRIPTION
We are not making use of the no-std feature
