### PR TITLE
feat: add updateOutputWithDescriptor for WrapPsbt

### DIFF
--- a/packages/wasm-miniscript/src/psbt.rs
+++ b/packages/wasm-miniscript/src/psbt.rs
@@ -43,6 +43,26 @@ impl WrapPsbt {
         }
     }
 
+    #[wasm_bindgen(js_name = updateOutputWithDescriptor)]
+    pub fn update_output_with_descriptor(
+        &mut self,
+        output_index: usize,
+        descriptor: WrapDescriptor,
+    ) -> Result<(), JsError> {
+        match descriptor.0 {
+            WrapDescriptorEnum::Definite(d) => self
+                .0
+                .update_output_with_descriptor(output_index, &d)
+                .map_err(JsError::from),
+            WrapDescriptorEnum::Derivable(_, _) => Err(JsError::new(
+                "Cannot update output with a derivable descriptor",
+            )),
+            WrapDescriptorEnum::String(_) => {
+                Err(JsError::new("Cannot update output with a string descriptor"))
+            }
+        }
+    }
+
     #[wasm_bindgen(js_name = finalize)]
     pub fn finalize_mut(&mut self) -> Result<(), JsError> {
         self.0

--- a/packages/wasm-miniscript/src/psbt.rs
+++ b/packages/wasm-miniscript/src/psbt.rs
@@ -57,9 +57,9 @@ impl WrapPsbt {
             WrapDescriptorEnum::Derivable(_, _) => Err(JsError::new(
                 "Cannot update output with a derivable descriptor",
             )),
-            WrapDescriptorEnum::String(_) => {
-                Err(JsError::new("Cannot update output with a string descriptor"))
-            }
+            WrapDescriptorEnum::String(_) => Err(JsError::new(
+                "Cannot update output with a string descriptor",
+            )),
         }
     }
 

--- a/packages/wasm-miniscript/test/psbt.ts
+++ b/packages/wasm-miniscript/test/psbt.ts
@@ -1,33 +1,12 @@
 import * as utxolib from "@bitgo/utxo-lib";
 import * as assert from "node:assert";
-import { getPsbtFixtures, toPsbtWithPrevOutOnly } from "./psbtFixtures";
+import { getPsbtFixtures } from "./psbtFixtures";
 import { Descriptor, Psbt } from "../js";
 
 import { getDescriptorForScriptType } from "./descriptorUtil";
+import { toUtxoPsbt, toWrappedPsbt } from "./psbt.util";
 
 const rootWalletKeys = new utxolib.bitgo.RootWalletKeys(utxolib.testutil.getKeyTriple("wasm"));
-
-function toWrappedPsbt(psbt: utxolib.bitgo.UtxoPsbt | Buffer | Uint8Array) {
-  if (psbt instanceof utxolib.bitgo.UtxoPsbt) {
-    psbt = psbt.toBuffer();
-  }
-  if (psbt instanceof Buffer || psbt instanceof Uint8Array) {
-    return Psbt.deserialize(psbt);
-  }
-  throw new Error("Invalid input");
-}
-
-function toUtxoPsbt(psbt: Psbt | Buffer | Uint8Array) {
-  if (psbt instanceof Psbt) {
-    psbt = psbt.serialize();
-  }
-  if (psbt instanceof Buffer || psbt instanceof Uint8Array) {
-    return utxolib.bitgo.UtxoPsbt.fromBuffer(Buffer.from(psbt), {
-      network: utxolib.networks.bitcoin,
-    });
-  }
-  throw new Error("Invalid input");
-}
 
 function assertEqualBuffer(a: Buffer | Uint8Array, b: Buffer | Uint8Array, message?: string) {
   assert.strictEqual(Buffer.from(a).toString("hex"), Buffer.from(b).toString("hex"), message);

--- a/packages/wasm-miniscript/test/psbt.util.ts
+++ b/packages/wasm-miniscript/test/psbt.util.ts
@@ -1,5 +1,5 @@
 import * as utxolib from "@bitgo/utxo-lib";
-import { Psbt } from "../js";
+import { Descriptor, Psbt } from "../js";
 
 export function toWrappedPsbt(psbt: utxolib.bitgo.UtxoPsbt | Buffer | Uint8Array) {
   if (psbt instanceof utxolib.bitgo.UtxoPsbt) {
@@ -21,4 +21,14 @@ export function toUtxoPsbt(psbt: Psbt | Buffer | Uint8Array) {
     });
   }
   throw new Error("Invalid input");
+}
+
+export function updateInputWithDescriptor(
+  psbt: utxolib.bitgo.UtxoPsbt,
+  inputIndex: number,
+  descriptor: Descriptor,
+) {
+  const wrappedPsbt = toWrappedPsbt(psbt);
+  wrappedPsbt.updateInputWithDescriptor(inputIndex, descriptor);
+  psbt.data.inputs[inputIndex] = toUtxoPsbt(wrappedPsbt).data.inputs[inputIndex];
 }

--- a/packages/wasm-miniscript/test/psbt.util.ts
+++ b/packages/wasm-miniscript/test/psbt.util.ts
@@ -1,3 +1,4 @@
+import * as assert from "node:assert";
 import * as utxolib from "@bitgo/utxo-lib";
 import { Descriptor, Psbt } from "../js";
 
@@ -37,6 +38,16 @@ export function updateInputWithDescriptor(
   psbt.data.inputs[inputIndex] = toUtxoPsbt(wrappedPsbt).data.inputs[inputIndex];
 }
 
+export function updateOutputWithDescriptor(
+  psbt: utxolib.Psbt,
+  outputIndex: number,
+  descriptor: Descriptor,
+) {
+  const wrappedPsbt = toWrappedPsbt(psbt);
+  wrappedPsbt.updateOutputWithDescriptor(outputIndex, descriptor);
+  psbt.data.outputs[outputIndex] = toUtxoPsbt(wrappedPsbt).data.outputs[outputIndex];
+}
+
 export function finalizePsbt(psbt: utxolib.Psbt) {
   const wrappedPsbt = toWrappedPsbt(psbt);
   wrappedPsbt.finalize();
@@ -44,4 +55,91 @@ export function finalizePsbt(psbt: utxolib.Psbt) {
   for (let i = 0; i < psbt.data.inputs.length; i++) {
     psbt.data.inputs[i] = unwrappedPsbt.data.inputs[i];
   }
+}
+
+function toEntries(k: string, v: unknown, path: (string | number)[]): [] | [[string, unknown]] {
+  if (matchPath(path, ["data", "inputs", any, "sighashType"])) {
+    return [];
+  }
+  if (matchPath(path.slice(-1), ["unknownKeyVals"])) {
+    if (Array.isArray(v) && v.length === 0) {
+      return [];
+    }
+  }
+  return [[k, toPlainObject(v, path)]];
+}
+
+const any = Symbol("any");
+
+function matchPath(path: (string | number)[], pattern: (string | number | symbol)[]) {
+  if (path.length !== pattern.length) {
+    return false;
+  }
+  for (let i = 0; i < path.length; i++) {
+    if (pattern[i] !== any && path[i] !== pattern[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function normalizeBip32Derivation(v: unknown) {
+  if (!Array.isArray(v)) {
+    throw new Error("Expected bip32Derivation to be an array");
+  }
+  return (
+    [...v] as {
+      masterFingerprint: Buffer;
+      path: string;
+    }[]
+  )
+    .map((e) => {
+      let { path } = e;
+      if (path.startsWith("m/")) {
+        path = path.slice(2);
+      }
+      return {
+        ...e,
+        path,
+      };
+    })
+    .sort((a, b) => a.masterFingerprint.toString().localeCompare(b.masterFingerprint.toString()));
+}
+
+function toPlainObject(v: unknown, path: (string | number)[]) {
+  // psbts have fun getters and other types of irregular properties that we mash into shape here
+  if (v === null || v === undefined) {
+    return v;
+  }
+  if (
+    matchPath(path, ["data", "inputs", any, "bip32Derivation"]) ||
+    matchPath(path, ["data", "outputs", any, "bip32Derivation"])
+  ) {
+    v = normalizeBip32Derivation(v);
+  }
+  switch (typeof v) {
+    case "number":
+    case "bigint":
+    case "string":
+    case "boolean":
+      return v;
+    case "object":
+      if (v instanceof Buffer || v instanceof Uint8Array) {
+        return v.toString("hex");
+      }
+      if (Array.isArray(v)) {
+        return v.map((v, i) => toPlainObject(v, [...path, i]));
+      }
+      return Object.fromEntries(
+        Object.entries(v)
+          .flatMap(([k, v]) => toEntries(k, v, [...path, k]))
+          .sort(([a], [b]) => a.localeCompare(b)),
+      );
+    default:
+      throw new Error(`Unsupported type: ${typeof v}`);
+  }
+}
+
+export function assertEqualPsbt(a: utxolib.Psbt, b: utxolib.Psbt) {
+  assert.deepStrictEqual(toPlainObject(a, []), toPlainObject(b, []));
 }

--- a/packages/wasm-miniscript/test/psbt.util.ts
+++ b/packages/wasm-miniscript/test/psbt.util.ts
@@ -1,8 +1,12 @@
 import * as utxolib from "@bitgo/utxo-lib";
 import { Descriptor, Psbt } from "../js";
 
-export function toWrappedPsbt(psbt: utxolib.bitgo.UtxoPsbt | Buffer | Uint8Array) {
-  if (psbt instanceof utxolib.bitgo.UtxoPsbt) {
+function toAddress(descriptor: Descriptor, network: utxolib.Network) {
+  utxolib.address.fromOutputScript(Buffer.from(descriptor.scriptPubkey()), network);
+}
+
+export function toWrappedPsbt(psbt: utxolib.bitgo.UtxoPsbt | utxolib.Psbt | Buffer | Uint8Array) {
+  if (psbt instanceof utxolib.bitgo.UtxoPsbt || psbt instanceof utxolib.Psbt) {
     psbt = psbt.toBuffer();
   }
   if (psbt instanceof Buffer || psbt instanceof Uint8Array) {
@@ -24,11 +28,20 @@ export function toUtxoPsbt(psbt: Psbt | Buffer | Uint8Array) {
 }
 
 export function updateInputWithDescriptor(
-  psbt: utxolib.bitgo.UtxoPsbt,
+  psbt: utxolib.Psbt,
   inputIndex: number,
   descriptor: Descriptor,
 ) {
   const wrappedPsbt = toWrappedPsbt(psbt);
   wrappedPsbt.updateInputWithDescriptor(inputIndex, descriptor);
   psbt.data.inputs[inputIndex] = toUtxoPsbt(wrappedPsbt).data.inputs[inputIndex];
+}
+
+export function finalizePsbt(psbt: utxolib.Psbt) {
+  const wrappedPsbt = toWrappedPsbt(psbt);
+  wrappedPsbt.finalize();
+  const unwrappedPsbt = toUtxoPsbt(wrappedPsbt);
+  for (let i = 0; i < psbt.data.inputs.length; i++) {
+    psbt.data.inputs[i] = unwrappedPsbt.data.inputs[i];
+  }
 }

--- a/packages/wasm-miniscript/test/psbt.util.ts
+++ b/packages/wasm-miniscript/test/psbt.util.ts
@@ -1,0 +1,24 @@
+import * as utxolib from "@bitgo/utxo-lib";
+import { Psbt } from "../js";
+
+export function toWrappedPsbt(psbt: utxolib.bitgo.UtxoPsbt | Buffer | Uint8Array) {
+  if (psbt instanceof utxolib.bitgo.UtxoPsbt) {
+    psbt = psbt.toBuffer();
+  }
+  if (psbt instanceof Buffer || psbt instanceof Uint8Array) {
+    return Psbt.deserialize(psbt);
+  }
+  throw new Error("Invalid input");
+}
+
+export function toUtxoPsbt(psbt: Psbt | Buffer | Uint8Array) {
+  if (psbt instanceof Psbt) {
+    psbt = psbt.serialize();
+  }
+  if (psbt instanceof Buffer || psbt instanceof Uint8Array) {
+    return utxolib.bitgo.UtxoPsbt.fromBuffer(Buffer.from(psbt), {
+      network: utxolib.networks.bitcoin,
+    });
+  }
+  throw new Error("Invalid input");
+}

--- a/packages/wasm-miniscript/test/psbtFixtures.ts
+++ b/packages/wasm-miniscript/test/psbtFixtures.ts
@@ -1,7 +1,7 @@
 import * as utxolib from "@bitgo/utxo-lib";
 import { RootWalletKeys } from "@bitgo/utxo-lib/dist/src/bitgo";
 
-type PsbtStage = "bare" | "unsigned" | "halfsigned" | "fullsigned";
+export type PsbtStage = "bare" | "unsigned" | "halfsigned" | "fullsigned";
 
 export function toPsbtWithPrevOutOnly(psbt: utxolib.bitgo.UtxoPsbt) {
   const psbtCopy = utxolib.bitgo.UtxoPsbt.createPsbt({
@@ -43,7 +43,8 @@ function getPsbtWithScriptTypeAndStage(
     [
       {
         value: BigInt(1e8 - 1000),
-        scriptType: "p2sh",
+        scriptType,
+        isInternalAddress: true,
       },
     ],
     utxolib.networks.bitcoin,


### PR DESCRIPTION
- **refactor: move psbt util functions to separate file**
  Issue: BTC-1451
  

- **feat: add updateInputWithDescriptor util**
  This util function allows working with native UtxoPsbt
  
  Issue: BTC-1451
  

- **feat: add finalizePsbt util**
  Issue: BTC-1451
  

- **feat: add updateOutputWithDescriptor to WrapPsbt**
  Issue: BTC-1451
  

- **feat: add tests for updateOutputWithDescriptor**
  Issue: BTC-1451
  