### PR TITLE
fix: pass descriptor by reference in update_*_with_descriptor

### DIFF
--- a/packages/wasm-miniscript/src/psbt.rs
+++ b/packages/wasm-miniscript/src/psbt.rs
@@ -27,9 +27,9 @@ impl WrapPsbt {
     pub fn update_input_with_descriptor(
         &mut self,
         input_index: usize,
-        descriptor: WrapDescriptor,
+        descriptor: &WrapDescriptor,
     ) -> Result<(), JsError> {
-        match descriptor.0 {
+        match &descriptor.0 {
             WrapDescriptorEnum::Definite(d) => self
                 .0
                 .update_input_with_descriptor(input_index, &d)
@@ -47,9 +47,9 @@ impl WrapPsbt {
     pub fn update_output_with_descriptor(
         &mut self,
         output_index: usize,
-        descriptor: WrapDescriptor,
+        descriptor: &WrapDescriptor,
     ) -> Result<(), JsError> {
-        match descriptor.0 {
+        match &descriptor.0 {
             WrapDescriptorEnum::Definite(d) => self
                 .0
                 .update_output_with_descriptor(output_index, &d)

--- a/packages/wasm-miniscript/test/psbt.ts
+++ b/packages/wasm-miniscript/test/psbt.ts
@@ -43,8 +43,9 @@ function describeUpdateInputWithDescriptor(
   describe("Wrapped PSBT updateInputWithDescriptor", function () {
     it("should update the input with the descriptor", function () {
       const wrappedPsbt = toWrappedPsbt(psbt);
-      wrappedPsbt.updateInputWithDescriptor(0, descriptor.atDerivationIndex(index));
-      wrappedPsbt.updateOutputWithDescriptor(0, descriptor.atDerivationIndex(index));
+      const descriptorAtDerivation = descriptor.atDerivationIndex(index);
+      wrappedPsbt.updateInputWithDescriptor(0, descriptorAtDerivation);
+      wrappedPsbt.updateOutputWithDescriptor(0, descriptorAtDerivation);
       const updatedPsbt = toUtxoPsbt(wrappedPsbt);
       assertEqualPsbt(updatedPsbt, getFixtureAtStage("unsigned").psbt);
       updatedPsbt.signAllInputsHD(rootWalletKeys.triple[0]);


### PR DESCRIPTION
This commit fixes a bug where the descriptor was being passed by value
instead of by reference in the `update_input_with_descriptor` and
`update_output_with_descriptor` methods of the `WrapPsbt` struct.

When passing by value, the `descriptor` variable was being moved into the
`match` statement. This consumed the `descriptor` variable, making it
impossible to use it again.

Issue: BTC-1743
