### PR TITLE
feat: update wasm-miniscript package and dependencies

### DIFF
--- a/packages/wasm-miniscript/Cargo.lock
+++ b/packages/wasm-miniscript/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "base58ck"
@@ -26,9 +26,9 @@ checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bitcoin"
-version = "0.32.2"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea507acc1cd80fc084ace38544bbcf7ced7c2aa65b653b102de0ce718df668f6"
+checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
 dependencies = [
  "base58ck",
  "bech32",
@@ -49,9 +49,9 @@ checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "340e09e8399c7bd8912f495af6aa58bea0c9214773417ffaa8f6460f93aaee56"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
 
 [[package]]
 name = "bitcoin-units"
@@ -74,15 +74,18 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "cc"
-version = "1.0.41"
+version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff"
+checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -107,18 +110,19 @@ checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "miniscript"
@@ -132,33 +136,39 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "secp256k1"
-version = "0.29.0"
+name = "rustversion"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+
+[[package]]
+name = "secp256k1"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes",
  "secp256k1-sys",
@@ -166,18 +176,24 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1433bd67156263443f14d603720b082dd3121779323fce20cba2aa07b874bc1b"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.68"
+name = "shlex"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "syn"
+version = "2.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -186,29 +202,30 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -217,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -227,9 +244,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -240,9 +257,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-miniscript"

--- a/packages/wasm-miniscript/Cargo.toml
+++ b/packages/wasm-miniscript/Cargo.toml
@@ -10,3 +10,8 @@ crate-type = ["cdylib"]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
 miniscript = { version = "12.3.0" }
+
+[profile.release]
+# this is required to make webpack happy
+# https://github.com/webpack/webpack/issues/15566#issuecomment-2558347645
+strip = true

--- a/packages/wasm-miniscript/Makefile
+++ b/packages/wasm-miniscript/Makefile
@@ -30,10 +30,10 @@ endef
 js/wasm/:
 	$(call BUILD,$@,nodejs)
 
-.PHONY: dist/wasm/
-dist/wasm/:
+.PHONY: dist/node/js/wasm/
+dist/node/js/wasm/:
 	$(call BUILD,$@,nodejs)
 
-.PHONY: dist/browser/wasm/
-dist/browser/wasm/:
+.PHONY: dist/browser/js/wasm/
+dist/browser/js/wasm/:
 	$(call BUILD,$@,browser)

--- a/packages/wasm-miniscript/package.json
+++ b/packages/wasm-miniscript/package.json
@@ -24,7 +24,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "sideEffects": [
-    "./dist/wasm/wasm_miniscript.js"
+    "./dist/wasm/wasm_miniscript.js",
+    "./dist/browser/wasm/wasm_miniscript.js"
   ],
   "browser": {
     "./dist/index.js": "./dist/browser/index.js",

--- a/packages/wasm-miniscript/package.json
+++ b/packages/wasm-miniscript/package.json
@@ -7,39 +7,29 @@
     "url": "git+https://github.com/BitGo/wasm-miniscript.git"
   },
   "files": [
-    "dist/wasm/wasm_miniscript.d.ts",
-    "dist/wasm/wasm_miniscript.js",
-    "dist/wasm/wasm_miniscript_bg.wasm",
-    "dist/wasm/wasm_miniscript_bg.wasm.d.ts",
-    "dist/browser/wasm/wasm_miniscript.d.ts",
-    "dist/browser/wasm/wasm_miniscript.js",
-    "dist/browser/wasm/wasm_miniscript_bg.js",
-    "dist/browser/wasm/wasm_miniscript_bg.wasm",
-    "dist/browser/wasm/wasm_miniscript_bg.wasm.d.ts",
-    "dist/browser/index.d.ts",
-    "dist/browser/index.js",
-    "dist/index.js",
-    "dist/index.d.ts"
+    "dist/*/js/wasm/wasm_miniscript.d.ts",
+    "dist/*/js/wasm/wasm_miniscript.js",
+    "dist/*/js/wasm/wasm_miniscript_bg.js",
+    "dist/*/js/wasm/wasm_miniscript_bg.wasm",
+    "dist/*/js/wasm/wasm_miniscript_bg.wasm.d.ts",
+    "dist/*/js/index.d.ts",
+    "dist/*/js/index.js"
   ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/node/js/index.js",
+  "types": "dist/node/js/index.d.ts",
   "sideEffects": [
-    "./dist/wasm/wasm_miniscript.js",
-    "./dist/browser/wasm/wasm_miniscript.js"
+    "./dist/node/js/wasm/wasm_miniscript.js",
+    "./dist/browser/js/wasm/wasm_miniscript.js"
   ],
   "browser": {
-    "./dist/index.js": "./dist/browser/index.js",
-    "./dist/index.d.ts": "./dist/browser/index.d.ts",
-    "./dist/wasm/wasm_miniscript_bg.wasm": "./dist/browser/wasm/wasm_miniscript_bg.wasm",
-    "./dist/wasm/wasm_miniscript.js": "./dist/browser/wasm/wasm_miniscript.js",
-    "./dist/wasm/wasm_miniscript_bg.js": "./dist/browser/wasm/wasm_miniscript_bg.js",
-    "./dist/wasm/wasm_miniscript.d.ts": "./dist/browser/wasm/wasm_miniscript.d.ts"
+    "./dist/node/js/index.js": "./dist/browser/js/index.js"
   },
   "scripts": {
     "test": "mocha --recursive test",
-    "build:wasm": "make js/wasm/ && make dist/wasm/ && make dist/browser/wasm/",
-    "build:ts-browser": "tsc --module es2020 --target es2020 --outDir dist/browser",
-    "build:ts": "tsc && npm run build:ts-browser",
+    "build:wasm": "make js/wasm/ && make dist/node/js/wasm/ && make dist/browser/js/wasm/",
+    "build:ts-browser": "tsc --noEmit false --module es2020 --target es2020 --outDir dist/browser",
+    "build:ts-node": "tsc --noEmit false --outDir dist/node",
+    "build:ts": "npm run build:ts-browser && npm run build:ts-node",
     "build": "npm run build:wasm && npm run build:ts",
     "check-fmt": "prettier --check . && cargo fmt -- --check"
   },

--- a/packages/wasm-miniscript/tsconfig.json
+++ b/packages/wasm-miniscript/tsconfig.json
@@ -7,8 +7,8 @@
     "allowJs": true,
     "skipLibCheck": true,
     "declaration": true,
-    "outDir": "dist"
+    "noEmit": true
   },
-  "include": ["./js/index.ts"],
+  "include": ["./js/**/*.ts", "test/**/*.ts"],
   "exclude": ["node_modules", "./js/wasm/**/*"]
 }


### PR DESCRIPTION

Update wasm-miniscript to latest dependencies and fix build configuration. 
Include test directory in TypeScript compilation but exclude from packaging. 
Add browser WASM file to sideEffects for proper bundling.

Ticket: BTC-1829