### PR TITLE
feat(psbt): add PSBT signing with xprv

### DIFF
--- a/packages/wasm-miniscript/js/index.ts
+++ b/packages/wasm-miniscript/js/index.ts
@@ -8,6 +8,10 @@ export type DescriptorPkType = "derivable" | "definite" | "string";
 
 export type ScriptContext = "tap" | "segwitv0" | "legacy";
 
+export type SignPsbtResult = {
+  [inputIndex: number]: [pubkey: string][];
+};
+
 declare module "./wasm/wasm_miniscript" {
   interface WrapDescriptor {
     /** These are not the same types of nodes as in the ast module */
@@ -26,6 +30,10 @@ declare module "./wasm/wasm_miniscript" {
   namespace WrapMiniscript {
     function fromString(miniscript: string, ctx: ScriptContext): WrapMiniscript;
     function fromBitcoinScript(script: Uint8Array, ctx: ScriptContext): WrapMiniscript;
+  }
+
+  interface WrapPsbt {
+    signWithXprv(this: WrapPsbt, xprv: string): SignPsbtResult;
   }
 }
 

--- a/packages/wasm-miniscript/src/try_into_js_value.rs
+++ b/packages/wasm-miniscript/src/try_into_js_value.rs
@@ -1,5 +1,6 @@
 use js_sys::Array;
 use miniscript::bitcoin::hashes::{hash160, ripemd160};
+use miniscript::bitcoin::psbt::{SigningKeys, SigningKeysMap};
 use miniscript::bitcoin::{PublicKey, XOnlyPublicKey};
 use miniscript::descriptor::{DescriptorType, ShInner, SortedMultiVec, TapTree, Tr, WshInner};
 use miniscript::{
@@ -254,5 +255,33 @@ impl TryIntoJsValue for DescriptorType {
     fn try_to_js_value(&self) -> Result<JsValue, JsError> {
         let str_from_enum = format!("{:?}", self);
         Ok(JsValue::from_str(&str_from_enum))
+    }
+}
+
+impl TryIntoJsValue for SigningKeys {
+    fn try_to_js_value(&self) -> Result<JsValue, JsError> {
+        match self {
+            SigningKeys::Ecdsa(v) => {
+                js_obj!("Ecdsa" => v)
+            }
+            SigningKeys::Schnorr(v) => {
+                js_obj!("Schnorr" => v)
+            }
+        }
+    }
+}
+
+impl TryIntoJsValue for SigningKeysMap {
+    fn try_to_js_value(&self) -> Result<JsValue, JsError> {
+        let obj = js_sys::Object::new();
+        for (key, value) in self.iter() {
+            js_sys::Reflect::set(
+                &obj,
+                &key.to_string().into(),
+                &value.try_to_js_value()?.into(),
+            )
+            .map_err(|_| JsError::new("Failed to set object property"))?;
+        }
+        Ok(obj.into())
     }
 }


### PR DESCRIPTION

Add method to sign PSBTs using extended private keys (xprv). Support 
signing with individual keys and return signed pubkeys map for tracking.

Issue: BTC-1845