### PR TITLE
feat(types): make SignPsbtResult type more precise

### DIFF
--- a/packages/wasm-miniscript/js/index.ts
+++ b/packages/wasm-miniscript/js/index.ts
@@ -8,8 +8,10 @@ export type DescriptorPkType = "derivable" | "definite" | "string";
 
 export type ScriptContext = "tap" | "segwitv0" | "legacy";
 
+export type SignPsbtInputResult = { Ecdsa: string[] } | { Schnorr: string[] };
+
 export type SignPsbtResult = {
-  [inputIndex: number]: [pubkey: string][];
+  [inputIndex: number]: SignPsbtInputResult;
 };
 
 declare module "./wasm/wasm_miniscript" {


### PR DESCRIPTION

Shape the sign result to indicate the type of signatures that were done: 
Ecdsa or Schnorr. Update tests to use the new type definitions and add
type checking with 'satisfies'.

References: BTC-1966